### PR TITLE
Improve display of origin

### DIFF
--- a/src/collar/oc_root.lsl
+++ b/src/collar/oc_root.lsl
@@ -45,7 +45,7 @@ string version = "6.6.0 BETA";
 
 string that_token = "global_";
 string about;
-string dist = "b1d9b76e-c311-4ee8-a562-cfab8b58614d";
+string dist;
 string safeword = "RED";
 integer locked;
 integer hidden;
@@ -103,7 +103,10 @@ menu_apps(key id, integer auth) {
 
 menu_about(key id) {
     string context = "\nVersion: "+version+"\nOrigin: ";
-    if (dist) context += uri("agent/"+dist);
+    if (osIsUUID(dist)) {
+        if (llKey2Name(dist)!="") context += uri("agent/"+dist);
+        else context += "Hypergrid";
+    }
     else context += "Unknown";
     context+="\n\n"+about;
     context+="\n\nThe OpenCollar Six™ scripts were used in this product to an unknown extent. The OpenCollar project can't support this product. Relevant [https://raw.githubusercontent.com/VirtualDisgrace/opencollar/master/LICENSE license terms] still apply.";
@@ -127,17 +130,20 @@ commands(integer auth, string str, key id, integer clicked) {
     } else if (str == "info" || str == "version") {
         string message = "\n\nModel: "+llGetObjectName();
         message += "\nVersion: "+version+"\nOrigin: ";
-        if (dist) message += uri("agent/"+dist);
+        if (osIsUUID(dist)) {
+            if (llKey2Name(dist)!="") message += uri("agent/"+dist);
+            else message += "Hypergrid";
+        }
         else message += "Unknown";
         message += "\nUser: "+llGetUsername(wearer);
         message += "\nPrefix: %PREFIX%\nChannel: %CHANNEL%\nSafeword: "+safeword+"\n";
         llMessageLinked(LINK_DIALOG,NOTIFY,"1"+message,id);
     } else if (str == "license") {
         if (llGetInventoryType(".license") == INVENTORY_NOTECARD) llGiveInventory(id,".license");
-        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no license file in this %DEVICETYPE%. Please request one directly from "+uri("agent/"+dist)+"!",id);
+        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no license file in this %DEVICETYPE%. Please request one directly from your distributor!",id);
     } else if (str == "help") {
         if (llGetInventoryType(".help") == INVENTORY_NOTECARD) llGiveInventory(id,".help");
-        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no help file in this %DEVICETYPE%. Please request one directly from "+uri("agent/"+dist)+"!",id);
+        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no help file in this %DEVICETYPE%. Please request one directly from your distributor!",id);
     } else if (str == "about") menu_about(id);
     else if (str == "apps") menu_apps(id,auth);
     else if (str == "settings") {

--- a/src/collar/oc_root.lsl
+++ b/src/collar/oc_root.lsl
@@ -271,7 +271,7 @@ default {
             string value = llList2String(params,1);
             if (this_token == that_token+"locked") locked = (integer)value;
             else if (this_token == that_token+"safeword") safeword = value;
-            else if (this_token == "intern_dist") dist = value;
+            //else if (this_token == "intern_dist") dist = value;
             else if (this_token == "intern_looks") looks = (integer)value;
         } else if (num == DIALOG_TIMEOUT) {
             integer menuindex = llListFindList(these_menus,[id]);

--- a/src/collar/oc_root.lsl
+++ b/src/collar/oc_root.lsl
@@ -140,10 +140,10 @@ commands(integer auth, string str, key id, integer clicked) {
         llMessageLinked(LINK_DIALOG,NOTIFY,"1"+message,id);
     } else if (str == "license") {
         if (llGetInventoryType(".license") == INVENTORY_NOTECARD) llGiveInventory(id,".license");
-        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no license file in this %DEVICETYPE%. Please request one directly from your distributor!",id);
+        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no license file in this %DEVICETYPE%. Please request one directly from the creator!",id);
     } else if (str == "help") {
         if (llGetInventoryType(".help") == INVENTORY_NOTECARD) llGiveInventory(id,".help");
-        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no help file in this %DEVICETYPE%. Please request one directly from your distributor!",id);
+        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no help file in this %DEVICETYPE%. Please request one directly from the creator!",id);
     } else if (str == "about") menu_about(id);
     else if (str == "apps") menu_apps(id,auth);
     else if (str == "settings") {

--- a/src/collar/oc_root.lsl
+++ b/src/collar/oc_root.lsl
@@ -45,8 +45,7 @@ string version = "6.6.0 BETA";
 
 string that_token = "global_";
 string about;
-string dist;            // creator avi key      example: "81a6d75f-73f8-4bab-ae50-e6180c3feaad"
-string origin_grid;     // griduri:port         example: "hg.example.com:8002"
+string dist;
 string safeword = "RED";
 integer locked;
 integer hidden;
@@ -104,7 +103,10 @@ menu_apps(key id, integer auth) {
 
 menu_about(key id) {
     string context = "\nVersion: "+version+"\nOrigin: ";
-    if (dist!="") context += uri(dist, origin_grid);
+    if (osIsUUID(dist)) {
+        if (llKey2Name(dist)!="") context += uri("agent/"+dist);
+        else context += "Hypergrid";
+    }
     else context += "Unknown";
     context+="\n\n"+about;
     context+="\n\nThe OpenCollar Six™ scripts were used in this product to an unknown extent. The OpenCollar project can't support this product. Relevant [https://raw.githubusercontent.com/VirtualDisgrace/opencollar/master/LICENSE license terms] still apply.";
@@ -128,17 +130,20 @@ commands(integer auth, string str, key id, integer clicked) {
     } else if (str == "info" || str == "version") {
         string message = "\n\nModel: "+llGetObjectName();
         message += "\nVersion: "+version+"\nOrigin: ";
-        if (dist!="") message += uri(dist, origin_grid);
+        if (osIsUUID(dist)) {
+            if (llKey2Name(dist)!="") message += uri("agent/"+dist);
+            else message += "Hypergrid";
+        }
         else message += "Unknown";
         message += "\nUser: "+llGetUsername(wearer);
         message += "\nPrefix: %PREFIX%\nChannel: %CHANNEL%\nSafeword: "+safeword+"\n";
         llMessageLinked(LINK_DIALOG,NOTIFY,"1"+message,id);
     } else if (str == "license") {
         if (llGetInventoryType(".license") == INVENTORY_NOTECARD) llGiveInventory(id,".license");
-        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no license file in this %DEVICETYPE%. Please request one directly from "+uri(dist, origin_grid)+"!",id);
+        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no license file in this %DEVICETYPE%. Please request one directly from your distributor!",id);
     } else if (str == "help") {
         if (llGetInventoryType(".help") == INVENTORY_NOTECARD) llGiveInventory(id,".help");
-        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no help file in this %DEVICETYPE%. Please request one directly from "+uri(dist, origin_grid)+"!",id);
+        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no help file in this %DEVICETYPE%. Please request one directly from your distributor!",id);
     } else if (str == "about") menu_about(id);
     else if (str == "apps") menu_apps(id,auth);
     else if (str == "settings") {
@@ -153,7 +158,7 @@ commands(integer auth, string str, key id, integer clicked) {
 
 failsafe() {
     string name = llGetScriptName();
-    if((key)name) return;
+    if(osIsUUID(name)) return;
     if(name != "oc_root") llRemoveInventory(name);
 }
 
@@ -175,9 +180,8 @@ init() {
     llSetTimerEvent(1.0);
 }
 
-string uri(string avi, string grid){
-    if (grid=="") return "secondlife:///app/agent/"+avi+"/inspect";
-    else return "hop://"+grid+"/app/agent/"+avi+"/inspect";
+string uri(string str){
+    return "secondlife:///app/"+str+"/inspect";
 }
 
 default {
@@ -271,7 +275,7 @@ default {
             string value = llList2String(params,1);
             if (this_token == that_token+"locked") locked = (integer)value;
             else if (this_token == that_token+"safeword") safeword = value;
-            //else if (this_token == "intern_dist") dist = value;
+            else if (this_token == "intern_dist") dist = value;
             else if (this_token == "intern_looks") looks = (integer)value;
         } else if (num == DIALOG_TIMEOUT) {
             integer menuindex = llListFindList(these_menus,[id]);

--- a/src/collar/oc_root.lsl
+++ b/src/collar/oc_root.lsl
@@ -45,7 +45,8 @@ string version = "6.6.0 BETA";
 
 string that_token = "global_";
 string about;
-string dist;
+string dist;            // creator avi key      example: "81a6d75f-73f8-4bab-ae50-e6180c3feaad"
+string origin_grid;     // griduri:port         example: "hg.example.com:8002"
 string safeword = "RED";
 integer locked;
 integer hidden;
@@ -103,10 +104,7 @@ menu_apps(key id, integer auth) {
 
 menu_about(key id) {
     string context = "\nVersion: "+version+"\nOrigin: ";
-    if (osIsUUID(dist)) {
-        if (llKey2Name(dist)!="") context += uri("agent/"+dist);
-        else context += "Hypergrid";
-    }
+    if (dist!="") context += uri(dist, origin_grid);
     else context += "Unknown";
     context+="\n\n"+about;
     context+="\n\nThe OpenCollar Six™ scripts were used in this product to an unknown extent. The OpenCollar project can't support this product. Relevant [https://raw.githubusercontent.com/VirtualDisgrace/opencollar/master/LICENSE license terms] still apply.";
@@ -130,20 +128,17 @@ commands(integer auth, string str, key id, integer clicked) {
     } else if (str == "info" || str == "version") {
         string message = "\n\nModel: "+llGetObjectName();
         message += "\nVersion: "+version+"\nOrigin: ";
-        if (osIsUUID(dist)) {
-            if (llKey2Name(dist)!="") message += uri("agent/"+dist);
-            else message += "Hypergrid";
-        }
+        if (dist!="") message += uri(dist, origin_grid);
         else message += "Unknown";
         message += "\nUser: "+llGetUsername(wearer);
         message += "\nPrefix: %PREFIX%\nChannel: %CHANNEL%\nSafeword: "+safeword+"\n";
         llMessageLinked(LINK_DIALOG,NOTIFY,"1"+message,id);
     } else if (str == "license") {
         if (llGetInventoryType(".license") == INVENTORY_NOTECARD) llGiveInventory(id,".license");
-        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no license file in this %DEVICETYPE%. Please request one directly from your distributor!",id);
+        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no license file in this %DEVICETYPE%. Please request one directly from "+uri(dist, origin_grid)+"!",id);
     } else if (str == "help") {
         if (llGetInventoryType(".help") == INVENTORY_NOTECARD) llGiveInventory(id,".help");
-        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no help file in this %DEVICETYPE%. Please request one directly from your distributor!",id);
+        else llMessageLinked(LINK_DIALOG,NOTIFY,"0"+"There is no help file in this %DEVICETYPE%. Please request one directly from "+uri(dist, origin_grid)+"!",id);
     } else if (str == "about") menu_about(id);
     else if (str == "apps") menu_apps(id,auth);
     else if (str == "settings") {
@@ -180,8 +175,9 @@ init() {
     llSetTimerEvent(1.0);
 }
 
-string uri(string str){
-    return "secondlife:///app/"+str+"/inspect";
+string uri(string avi, string grid){
+    if (grid=="") return "secondlife:///app/agent/"+avi+"/inspect";
+    else return "hop://"+grid+"/app/agent/"+avi+"/inspect";
 }
 
 default {

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -400,7 +400,7 @@ UserCommand(integer iAuth, string sStr, key kID) {
 default {
     state_entry() {
         if (llGetStartParameter()==825) llSetRemoteScriptAccessPin(0);
-        //if (llGetNumberOfPrims()>5) g_lSettings = ["intern_dist",(string)llGetObjectDetails(llGetLinkKey(1),[27])];
+        if (llGetNumberOfPrims()>5) g_lSettings = ["intern_dist",(string)llGetObjectDetails(llGetLinkKey(llGetNumberOfPrims()),[OBJECT_CREATOR])];
         FailSafe(0);
         // Ensure that settings resets AFTER every other script, so that they don't reset after they get settings
         llSleep(0.5);

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -400,7 +400,7 @@ UserCommand(integer iAuth, string sStr, key kID) {
 default {
     state_entry() {
         if (llGetStartParameter()==825) llSetRemoteScriptAccessPin(0);
-        if (llGetNumberOfPrims()>5) g_lSettings = ["intern_dist",(string)llGetObjectDetails(llGetLinkKey(llGetNumberOfPrims()),[OBJECT_CREATOR])];
+        //if (llGetNumberOfPrims()>5) g_lSettings = ["intern_dist",(string)llGetObjectDetails(llGetLinkKey(1),[27])];
         FailSafe(0);
         // Ensure that settings resets AFTER every other script, so that they don't reset after they get settings
         llSleep(0.5);

--- a/src/collar/oc_settings.lsl
+++ b/src/collar/oc_settings.lsl
@@ -400,7 +400,7 @@ UserCommand(integer iAuth, string sStr, key kID) {
 default {
     state_entry() {
         if (llGetStartParameter()==825) llSetRemoteScriptAccessPin(0);
-        if (llGetNumberOfPrims()>5) g_lSettings = ["intern_dist",(string)llGetObjectDetails(llGetLinkKey(1),[27])];
+        if (llGetNumberOfPrims()>5) g_lSettings = ["intern_dist",(string)llGetObjectDetails(llGetLinkKey(llGetNumberOfPrims()),[OBJECT_CREATOR])];
         FailSafe(0);
         // Ensure that settings resets AFTER every other script, so that they don't reset after they get settings
         llSleep(0.5);


### PR DESCRIPTION
The origin will show as clickable profile link IF the creator is on the same local grid; else it will show 'Hypergrid'. Since OpenSim disallows essential hypergrid ossl functions like osKey2Name() by default, we'll have to do with this.